### PR TITLE
Speed up (using mamba) and fix the CI; better installation documentation

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,6 +1,9 @@
 # Based roughly on the main.yml and standalone.yml workflows in
 # https://github.com/biocore/empress/blob/master/.github/workflows/,
-# and on https://docs.github.com/en/actions/quickstart
+# https://docs.github.com/en/actions/quickstart, and
+# https://github.com/fedarko/wotplot/blob/ce702b63bf790c41d02b0493e3a7eebda6fcec70/.github/workflows/main.yml
+# (which i based off of this file originally, so it's an ouroboros of me
+# copying code from myself because i can never remember how yaml works)
 name: strainFlye CI
 on: [push, pull_request]
 jobs:
@@ -22,35 +25,29 @@ jobs:
       - name: Check out code
         uses: actions/checkout@v3
 
-      # https://github.com/conda-incubator/setup-miniconda#example-3-other-options
-      - name: Install conda dependencies
-        uses: conda-incubator/setup-miniconda@v2
+      # https://github.com/mamba-org/setup-micromamba
+      - name: Install conda dependencies with mamba
+        uses: mamba-org/setup-micromamba@v1
         with:
-          activate-environment: strainflye
           environment-file: environment.yml
-          python-version: ${{ matrix.python-version }}
+          create-args: python=${{ matrix.python-version }}
+          init-shell: bash
 
-      # We need to keep saying "run this command from within the 'strainflye'
-      # conda environment", and we can do this easily by prefixing commands
-      # with "conda run -n" (as done in EMPress' main.yml file, linked above).
-      # I don't know of a more elegant way to do this; I do know that
-      # installing everything into the "base" environment (as done in, e.g.,
-      # https://autobencoder.com/2020-08-24-conda-actions) would remove the
-      # need to keep re-activating the strainflye environment, but it'd have
-      # the effect of polluting the base environment (which is not ideal
-      # practice, according to
-      # https://github.com/marketplace/actions/setup-miniconda#environment-activation).
       - name: Install strainFlye (and pip dependencies)
-        run: conda run -n strainflye pip install -e .[dev]
-
-      - name: Run tests
-        run: conda run -n strainflye make test
-
-      - name: Check that the strainFlye CLI seems good
-        run: conda run -n strainflye strainFlye
+        run: pip install -e .[dev]
+        shell: bash -el {0}
 
       - name: Lint and stylecheck
-        run: conda run -n strainflye make stylecheck
+        run: make stylecheck
+        shell: bash -el {0}
+
+      - name: Run tests
+        run: make test
+        shell: bash -el {0}
+
+      - name: Check that the strainFlye CLI seems good
+        run: strainFlye
+        shell: bash -el {0}
 
       - name: Upload code coverage information to Codecov
         uses: codecov/codecov-action@v2

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -36,7 +36,7 @@ faster. As of writing, probably the easiest way to do this is to create an
 empty environment and then
 [update it based on `environment.yml`](https://github.com/mamba-org/mamba/issues/633#issuecomment-812272143).
 
-### Sidenote: installing LJA for `strainFlye smooth assemble`
+### Sidenote: installing LJA in order to use `strainFlye smooth assemble`
 
 If you want to work on `strainFlye smooth assemble` then you may also want to
 install [LJA](https://github.com/AntonBankevich/LJA), as is discussed in the

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,9 +28,19 @@ conda activate strainflye
 pip install -e .[dev]
 ```
 
+### Sidenote: using mamba instead of conda
+
+You may prefer to create the environment using
+[mamba](https://mamba.readthedocs.io) instead of conda, since mamba can be much
+faster. As of writing, probably the easiest way to do this is to create an
+empty environment and then
+[update it based on `environment.yml`](https://github.com/mamba-org/mamba/issues/633#issuecomment-812272143).
+
+### Sidenote: installing LJA for `strainFlye smooth assemble`
+
 If you want to work on `strainFlye smooth assemble` then you may also want to
-install [LJA](https://github.com/AntonBankevich/LJA), as discussed in the
-strainFlye README. (That said, as of writing strainFlye's tests do not rely on
+install [LJA](https://github.com/AntonBankevich/LJA), as is discussed in the
+strainFlye README. (That said: as of writing strainFlye's tests do not rely on
 LJA being installed, so this step is optional.)
 
 ## Development commands

--- a/README.md
+++ b/README.md
@@ -82,27 +82,29 @@ strainFlye is available through the [bioconda](https://bioconda.github.io/)
 channel:
 
 <!-- using HTML table syntax to work nicely with code blocks; see
-https://gist.github.com/MarcoEidinger/c0f0583f19baca0a8f33bcded644be41 -->
+https://gist.github.com/MarcoEidinger/c0f0583f19baca0a8f33bcded644be41
+(also i wanted to indent the HTML tags but github markdown doesn't seem to like
+that, so that's why my HTML code here looks uglier than usual :() -->
 <table>
-  <tr>
-    <th>Using conda</th><th>Using mamba</th>
-  </tr>
-  <tr>
-    <td>
+<tr>
+<th>Using conda</th><th>Using mamba</th>
+</tr>
+<tr>
+<td>
 
 ```bash
 conda install -c bioconda strainflye
 ```
 
-    </td>
-    <td>
+</td>
+<td>
 
 ```bash
 mamba install -c bioconda strainflye
 ```
 
-    </td>
-  </tr>
+</td>
+</tr>
 </table>
 
 

--- a/README.md
+++ b/README.md
@@ -89,7 +89,9 @@ conda install -c bioconda strainflye
 
 - If you run into dependency conflicts when installing strainFlye into an
   existing conda environment, you may want to just create a new conda environment
-  and install strainFlye into that.
+  and install strainFlye into that. (See the "workaround solution" given in
+  [this issue](https://github.com/fedarko/strainFlye/issues/70) for an
+  example.)
 
 - If that still doesn't work, you can try installing from source -- see below.
 

--- a/README.md
+++ b/README.md
@@ -85,10 +85,16 @@ channel:
 conda install -c bioconda strainflye
 ```
 
-If you run into dependency conflicts when installing strainFlye into an
-existing conda environment, you may want to just create a new conda environment
-and install strainFlye into that. And if that still doesn't work, you can try
-installing from source -- see below.
+#### Sidenote: troubleshooting installation
+
+- If you run into dependency conflicts when installing strainFlye into an
+  existing conda environment, you may want to just create a new conda environment
+  and install strainFlye into that.
+
+- If that still doesn't work, you can try installing from source -- see below.
+
+- And if _that_ doesn't work, no worries -- installing this stuff can be finicky.
+  Feel free to open an issue and I'll try to help out.
 
 ### Installation from source
 

--- a/README.md
+++ b/README.md
@@ -81,32 +81,9 @@ The simplest way to install strainFlye is by using
 strainFlye is available through the [bioconda](https://bioconda.github.io/)
 channel:
 
-<!-- using HTML table syntax to work nicely with code blocks; see
-https://gist.github.com/MarcoEidinger/c0f0583f19baca0a8f33bcded644be41
-(also i wanted to indent the HTML tags but github markdown doesn't seem to like
-that, so that's why my HTML code here looks uglier than usual :() -->
-<table>
-<tr>
-<th>Using conda</th><th>Using mamba</th>
-</tr>
-<tr>
-<td>
-
 ```bash
 conda install -c bioconda strainflye
 ```
-
-</td>
-<td>
-
-```bash
-mamba install -c bioconda strainflye
-```
-
-</td>
-</tr>
-</table>
-
 
 If you run into dependency conflicts when installing strainFlye into an
 existing conda environment, you may want to just create a new conda environment

--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ channel:
 conda install -c bioconda strainflye
 ```
 
-#### Sidenote: troubleshooting installation
+#### Sidenote: troubleshooting installation problems
 
 - If you run into dependency conflicts when installing strainFlye into an
   existing conda environment, you may want to just create a new conda environment

--- a/README.md
+++ b/README.md
@@ -77,16 +77,39 @@ supporting Python 3.6 and 3.7). strainFlye depends on a few non-Python tools
 ### Installation using conda (recommended)
 
 The simplest way to install strainFlye is by using
-[conda](https://conda.io/). strainFlye is available through the
-[bioconda](https://bioconda.github.io/) channel:
+[conda](https://conda.io/) (or [mamba](https://mamba.readthedocs.io)).
+strainFlye is available through the [bioconda](https://bioconda.github.io/)
+channel:
+
+<!-- using HTML table syntax to work nicely with code blocks; see
+https://gist.github.com/MarcoEidinger/c0f0583f19baca0a8f33bcded644be41 -->
+<table>
+  <tr>
+    <th>Using conda</th><th>Using mamba</th>
+  </tr>
+  <tr>
+    <td>
 
 ```bash
 conda install -c bioconda strainflye
 ```
 
-(If you run into dependency conflicts when installing strainFlye into an
+    </td>
+    <td>
+
+```bash
+mamba install -c bioconda strainflye
+```
+
+    </td>
+  </tr>
+</table>
+
+
+If you run into dependency conflicts when installing strainFlye into an
 existing conda environment, you may want to just create a new conda environment
-and install strainFlye into that.)
+and install strainFlye into that. And if that still doesn't work, you can try
+installing from source -- see below.
 
 ### Installation from source
 

--- a/environment.yml
+++ b/environment.yml
@@ -2,11 +2,11 @@ name: strainflye
 channels:
     - conda-forge
     - bioconda
-    - defaults
+    - nodefaults
 dependencies:
     # HACK to accommodate pysam / pysamstats for now -- see
     # https://github.com/fedarko/strainFlye/issues/8
-    - python >= 3.6, <= 3.7
+    - python >= 3.6, < 3.8
 
     # Based on what pysam and pysamstats use currently -- see
     # https://github.com/pysam-developers/pysam/blob/master/requirements.txt
@@ -44,4 +44,4 @@ dependencies:
 
     # Installing this with pip gives errors (at least as of Summer 2023), so we
     # include it here to fix the build
-    - scikit-bio >= 0.5.8
+    - scikit-bio

--- a/environment.yml
+++ b/environment.yml
@@ -44,4 +44,4 @@ dependencies:
 
     # Installing this with pip gives errors (at least as of Summer 2023), so we
     # include it here to fix the build
-    - scikit-bio
+    - scikit-bio >= 0.5.8

--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,7 @@ setup(
     url="https://github.com/fedarko/strainFlye",
     packages=find_packages(),
     install_requires=[
-        "scikit-bio",
+        "scikit-bio >= 0.5.8",
         "networkx",
         # Also not a hard requirement.
         "pandas >= 1.0",

--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,7 @@ setup(
     url="https://github.com/fedarko/strainFlye",
     packages=find_packages(),
     install_requires=[
-        "scikit-bio >= 0.5.8",
+        "scikit-bio",
         "networkx",
         # Also not a hard requirement.
         "pandas >= 1.0",


### PR DESCRIPTION
Closes #68.

Switched to mamba and replaced the `defaults` channel in the environment YAML with `nodefaults`, since mixing `defaults` and `conda-forge` causes problems for mamba (https://mamba.readthedocs.io/en/latest/user_guide/troubleshooting.html#mixing-the-defaults-and-conda-forge-channels). This combination of changes fixed and sped up the build.

I also updated the dev documentation (to mention using mamba instead of conda) and updated the environment YAML's upper limit on Python from `<= 3.7` to `< 3.8` (I think this is a more accurate way of writing this out, plus it matches what I already had in the `setup.py` and bioconda recipe files...)